### PR TITLE
allow optional removal of public packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ Number of versions to keep per package. Defaults to `5`.
 
 Whether or not to remove [semantic versions](https://semver.org/). Defaults to `false`.
 
+### `remove-public`
+
+Whether or not to remove packages from public repos. Defaults to `false`.
+
 Keep in mind that if you use date-based versions with `.` as a separator, for instance `yyyy.mm.dd-<sha>`, some dates are valid semantic versions, while others aren't. The ones who aren't valid semantic versions are the ones who have the month or day parts of the date starting with `0`, for instance `2019.12.01`. When using date-based versions it's advisable to use `-` as a separator instead of `.`.
 
 ## Output

--- a/action.php
+++ b/action.php
@@ -50,6 +50,7 @@ function isSemanticVersion(string $version) : bool {
 $token             = (string) getenv('GITHUB_TOKEN');
 $keepVersions      = (int) getenv('INPUT_KEEP_VERSIONS') ?: 5;
 $removeSemver      = 'true' === getenv('INPUT_REMOVE_SEMVER');
+$removePublic      = 'true' === getenv('INPUT_REMOVE_PUBLIC');
 $repoNameWithOwner = (string) getenv('GITHUB_REPOSITORY');
 $clientId          = 'navikt/remove-package-versions';
 
@@ -116,8 +117,8 @@ $repository = json_decode($response->getBody()->getContents(), true)['data']['re
 
 if (null === $repository) {
     fail(sprintf('[%s] Repository not found', $repoNameWithOwner));
-} else if (!$repository['isPrivate']) {
-    fail(sprintf('[%s] Repository is public, unable to remove package versions', $repoNameWithOwner));
+} else if (!$repository['isPrivate'] && !removePublic) {
+    fail(sprintf('[%s] Repository is public, unable to remove package versions unless remove-public is set to true', $repoNameWithOwner));
 }
 
 $packageNodes = $repository['packages']['nodes'] ?? [];

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,10 @@ inputs:
     description: Whether or not to remove semver versions
     required: true
     default: "false"
+  remove-public:
+    description: Whether or not to remove packages from public repos
+    required: true
+    default: "false"
 outputs:
   removed-package-versions:
     description: A list of package versions that was removed


### PR DESCRIPTION
No need to waste shedloads of disk space preserving old versions of internal stuff even though it's public. If an old version is needed for some reason it can always be rebuilt.