### PR TITLE
Fix for input parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,11 +64,11 @@ This environment variable is automatically available inside a workflow run, and 
 
 The action supports the following parameters:
 
-### `keep-versions`
+### `keep_versions`
 
 Number of versions to keep per package. Defaults to `5`.
 
-### `remove-semver`
+### `remove_semver`
 
 Whether or not to remove [semantic versions](https://semver.org/). Defaults to `false`.
 
@@ -76,4 +76,4 @@ Keep in mind that if you use date-based versions with `.` as a separator, for in
 
 ## Output
 
-The action outputs a JSON-encoded list of removed package versions prefixed with the owner and the repository name. The name of the output is `removed-package-versions`. Using the `id` from the workflow example above, you can refer to the output using `${{ steps.remove-package-versions.outputs.removed-package-versions }}`.
+The action outputs a JSON-encoded list of removed package versions prefixed with the owner and the repository name. The name of the output is `removed_package_versions`. Using the `id` from the workflow example above, you can refer to the output using `${{ steps.remove-package-versions.outputs.removed_package_versions }}`.

--- a/action.php
+++ b/action.php
@@ -48,8 +48,8 @@ function isSemanticVersion(string $version) : bool {
 }
 
 $token             = (string) getenv('GITHUB_TOKEN');
-$keepVersions      = (int) getenv('INPUT_KEEP_VERSIONS') ?: 5;
-$removeSemver      = 'true' === getenv('INPUT_REMOVE_SEMVER');
+$keepVersions      = (int) getenv('INPUT_KEEP-VERSIONS') ?: 5;
+$removeSemver      = 'true' === getenv('INPUT_REMOVE-SEMVER');
 $repoNameWithOwner = (string) getenv('GITHUB_REPOSITORY');
 $clientId          = 'navikt/remove-package-versions';
 

--- a/action.php
+++ b/action.php
@@ -48,8 +48,8 @@ function isSemanticVersion(string $version) : bool {
 }
 
 $token             = (string) getenv('GITHUB_TOKEN');
-$keepVersions      = (int) getenv('INPUT_KEEP-VERSIONS') ?: 5;
-$removeSemver      = 'true' === getenv('INPUT_REMOVE-SEMVER');
+$keepVersions      = (int) getenv('INPUT_KEEP_VERSIONS') ?: 5;
+$removeSemver      = 'true' === getenv('INPUT_REMOVE_SEMVER');
 $repoNameWithOwner = (string) getenv('GITHUB_REPOSITORY');
 $clientId          = 'navikt/remove-package-versions';
 
@@ -174,6 +174,6 @@ foreach ($packageNodes as $packageNode) {
     }
 }
 
-echo sprintf('::set-output name=removed-package-versions::%s', json_encode(array_map(function(string $version) use ($repoNameWithOwner) : string {
+echo sprintf('::set-output name=removed_package_versions::%s', json_encode(array_map(function(string $version) use ($repoNameWithOwner) : string {
     return sprintf('%s/%s', $repoNameWithOwner, $version);
 }, $removedPackages))) . PHP_EOL;

--- a/action.yml
+++ b/action.yml
@@ -2,16 +2,16 @@ name: Remove package versions from GitHub Packages
 author: Christer Edvartsen
 description: Clean up older versions of private packages in GitHub Packages
 inputs:
-  keep-versions:
+  keep_versions:
     description: Number of versions to keep
     required: true
     default: "5"
-  remove-semver:
+  remove_semver:
     description: Whether or not to remove semver versions
     required: true
     default: "false"
 outputs:
-  removed-package-versions:
+  removed_package_versions:
     description: A list of package versions that was removed
 runs:
   using: docker


### PR DESCRIPTION
The readme says input is with hyphen (i.e. 'keep-versions') and not with underscore.