### PR TITLE
Add keep_latest input, defaulting to true

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Number of versions to keep per package. Defaults to `5`.
 
 ### `keep_latest`
 
-Wheter or not to remove 'latest' package. Defaults to `true`.
+Wheter or not to keep the `latest` version. Defaults to `true`.
 
 ### `remove_semver`
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ The action supports the following parameters:
 
 Number of versions to keep per package. Defaults to `5`.
 
+### `keep_latest``
+
+Wheter or not to remove 'latest' package. Defaults to `true`.
+
 ### `remove_semver`
 
 Whether or not to remove [semantic versions](https://semver.org/). Defaults to `false`.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The action supports the following parameters:
 
 Number of versions to keep per package. Defaults to `5`.
 
-### `keep_latest``
+### `keep_latest`
 
 Wheter or not to remove 'latest' package. Defaults to `true`.
 

--- a/action.php
+++ b/action.php
@@ -61,6 +61,7 @@ function isSemanticVersion(string $version) : bool {
 
 $token             = env('GITHUB_TOKEN');
 $keepVersions      = (int) env('INPUT_KEEP_VERSIONS') ?: 5;
+$keepLatest        = 'true' === env('INPUT_KEEP_LATEST');
 $removeSemver      = 'true' === env('INPUT_REMOVE_SEMVER');
 $repoNameWithOwner = env('GITHUB_REPOSITORY');
 $clientId          = 'navikt/remove-package-versions';
@@ -141,14 +142,17 @@ if (empty($packageNodes)) {
 $removedPackages = [];
 
 // List of versions to always keep
+
 $keepVersions = [
     // Removing this specific version of a Docker package triggers a bug in GitHub
     // Packages. Keep this safeguard until the bug has been resolved.
-    'docker-base-layer',
-
-    // Do not remove 'latest' version of package
-    'latest',
+    'docker-base-layer'
 ];
+
+if($keepLatest) {
+  // Do not remove 'latest' version of package
+  $keepVersions += ['latest'];  
+}
 
 foreach ($packageNodes as $packageNode) {
     $packageName = $packageNode['name'];

--- a/action.php
+++ b/action.php
@@ -142,16 +142,14 @@ if (empty($packageNodes)) {
 $removedPackages = [];
 
 // List of versions to always keep
-
 $keepVersions = [
     // Removing this specific version of a Docker package triggers a bug in GitHub
     // Packages. Keep this safeguard until the bug has been resolved.
     'docker-base-layer'
 ];
 
-if($keepLatest) {
-  // Do not remove 'latest' version of package
-  $keepVersions += ['latest'];  
+if ($keepLatest) {
+    $keepVersions[] = 'latest';
 }
 
 foreach ($packageNodes as $packageNode) {

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,10 @@ inputs:
     description: Number of versions to keep
     required: true
     default: "5"
+  keep_latest:
+    description: Wheter or not to remove latest versions
+    required: true
+    default: "true"
   remove_semver:
     description: Whether or not to remove semver versions
     required: true

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ inputs:
     required: true
     default: "5"
   keep_latest:
-    description: Wheter or not to remove latest versions
+    description: Wheter or not to keep the latest version
     required: true
     default: "true"
   remove_semver:


### PR DESCRIPTION
Adds a `keep_latest ` input to configure wether or not the "latest" package should be deleted.

Since PR #4 introduced the "keep latest package" behaviour and made it a default behaviour for this github action it makes sense to enable the `keep_latest` input by default too.

Enhances #3